### PR TITLE
updated deprecated rspec error-checking syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tags
 vendor/bundle
 /doc
 .yardoc/
+.bin

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ tags
 vendor/bundle
 /doc
 .yardoc/
-.bin

--- a/spec/lib/reveille/event/hook_spec.rb
+++ b/spec/lib/reveille/event/hook_spec.rb
@@ -9,8 +9,8 @@ describe Reveille::Event::Hook do
       end
       let(:hook) { klass.new }
       it 'enforces required attributes' do
-        expect { hook.name }.to raise_error(StandardError)
-        expect { hook.events }.to raise_error(StandardError)
+        expect { hook.name }.to raise_error()
+        expect { hook.events }.to raise_error()
       end
     end
 
@@ -24,8 +24,8 @@ describe Reveille::Event::Hook do
       let(:hook) { klass.new }
 
       it 'valid with valid attribute methods' do
-        expect { hook.name }.not_to raise_error(StandardError)
-        expect { hook.events }.not_to raise_error(StandardError)
+        expect { hook.name }.not_to raise_error()
+        expect { hook.events }.not_to raise_error()
         expect(hook.name).to eq "test_hook"
         expect(hook.events).to eq [ 'foo.bar' ]
       end


### PR DESCRIPTION
Accidentally got a .gitignore commit and revert in here, but this commit cleans out one of the deprecated errors rspec throws. Apparently they don't want you specifying what type of error you're hoping to not see when any error type would be unwanted.
