### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.0.2)
       sprockets-rails (~> 2.0.0)
-    rails_best_practices (1.15.0)
+    rails_best_practices (1.16.0)
       awesome_print
       code_analyzer (>= 0.4.3)
       colored

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.3)
       ffi (>= 0.5.0)
-    rblineprof (0.3.6)
+    rblineprof (>=0.3.6)
       debugger-ruby_core_source (~> 1.3)
     rbtrace (0.4.2)
       ffi (>= 1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.3)
       ffi (>= 0.5.0)
-    rblineprof (>=0.3.6)
+    rblineprof (>= 0.3.6)
       debugger-ruby_core_source (~> 1.3)
     rbtrace (0.4.2)
       ffi (>= 1.0.6)


### PR DESCRIPTION
Could not find rails_best_practices-1.15.0 in any of the sources
